### PR TITLE
Remove handle_terminate_request callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_realtimer_plugin` to your list 
 ```elixir
 def deps do
   [
-    {:membrane_realtimer_plugin, "~> 0.6.0"}
+    {:membrane_realtimer_plugin, "~> 0.6.1"}
   ]
 end
 ```

--- a/lib/membrane/realtimer.ex
+++ b/lib/membrane/realtimer.ex
@@ -76,9 +76,4 @@ defmodule Membrane.Realtimer do
 
     {actions, %{state | tick_actions: []}}
   end
-
-  @impl true
-  def handle_terminate_request(_ctx, state) do
-    {[stop_timer: :timer], %{state | previous_timestamp: 0}}
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Realtimer.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
   @github_url "https://github.com/membraneframework/membrane_realtimer_plugin"
 
   def project do

--- a/test/membrane_realtimer_test.exs
+++ b/test/membrane_realtimer_test.exs
@@ -26,6 +26,5 @@ defmodule Membrane.RealtimerTest do
     assert_sink_buffer(pipeline, :sink, %Buffer{payload: 1}, 20)
     assert_end_of_stream(pipeline, :sink)
     refute_sink_buffer(pipeline, :sink, _buffer, 0)
-    Testing.Pipeline.terminate(pipeline, blocking?: true)
   end
 end

--- a/test/membrane_realtimer_test.exs
+++ b/test/membrane_realtimer_test.exs
@@ -26,5 +26,6 @@ defmodule Membrane.RealtimerTest do
     assert_sink_buffer(pipeline, :sink, %Buffer{payload: 1}, 20)
     assert_end_of_stream(pipeline, :sink)
     refute_sink_buffer(pipeline, :sink, _buffer, 0)
+    Testing.Pipeline.terminate(pipeline, blocking?: true)
   end
 end


### PR DESCRIPTION
There was a mistake during updating to core 0.11. Callback handle_playing_to_prepared was changed to handle_terminate_request which caused element to never terminate and be in endless state of termination pending.